### PR TITLE
travis: upgrade Python version in test suit 3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,9 +20,9 @@ language: python
 
 python:
   - "2.7"
-  - "3.3"
   - "3.4"
   - "3.5"
+  - "3.6"
 
 env:
   - REQUIREMENTS=lowest

--- a/setup.py
+++ b/setup.py
@@ -89,8 +89,8 @@ setup(
         'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
     ],
 )


### PR DESCRIPTION
* INCOMPATIBLE Python 3.3 is not supported anymore from the
  sphinx library and it is not supported also from the INVENIO team