### PR TITLE
idutils: make DOIs without suffix invalid

### DIFF
--- a/idutils/__init__.py
+++ b/idutils/__init__.py
@@ -24,7 +24,7 @@ from six.moves.urllib.parse import urlparse
 from .version import __version__
 
 doi_regexp = re.compile(
-    "(doi:\s*|(?:https?://)?(?:dx\.)?doi\.org/)?(10\.\d+(.\d+)*/.*)$",
+    "(doi:\s*|(?:https?://)?(?:dx\.)?doi\.org/)?(10\.\d+(.\d+)*/.+)$",
     flags=re.I
 )
 """See http://en.wikipedia.org/wiki/Digital_object_identifier."""

--- a/tests/test_idutils.py
+++ b/tests/test_idutils.py
@@ -202,3 +202,10 @@ def test_compund_isbn():
     assert idutils.is_isbn('0-9752298-0-X')
     assert not idutils.is_isbn13('0-9752298-0-X')
     assert idutils.is_isbn10('0-9752298-0-X')
+
+
+def test_doi():
+    """Test DOI validation."""
+    assert idutils.is_doi('10.1000/123456')
+    assert idutils.is_doi('10.1038/issn.1476-4687')
+    assert not idutils.is_doi('10.1000/')


### PR DESCRIPTION
From https://www.doi.org/doi_handbook/2_Numbering.html#2.2.1:
> The DOI syntax shall be made up of a DOI prefix and a DOI suffix separated by a forward slash.

This PR makes the suffix required, which was not the case previously.