### PR TITLE
Add the HAL (hal.archives-ouvertes.fr) id style

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -1,6 +1,6 @@
 ..
    This file is part of IDUtils
-   Copyright (C) 2015, 2016 CERN.
+   Copyright (C) 2015-2019 CERN.
 
    IDUtils is free software; you can redistribute it and/or modify
    it under the terms of the Revised BSD License; see LICENSE file for

--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -17,6 +17,7 @@ Authors
 - Adrian Pawel Baran
 - Alan Rubin
 - Alexander Ioannidis
+- Bruno Marmol
 - Jiri Kuncar
 - Lars Holm Nielsen
 - Pedro Gaudencio

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,10 @@
 Changes
 =======
 
+Version 1.1.2 (2019-02-12)
+
+- Adds support for HAL identifiers.
+
 Version 1.1.1 (2018-11-18)
 
 - Changes URL resolution for bibcodes to use https://ui.adsabs.harvard instead

--- a/idutils/__init__.py
+++ b/idutils/__init__.py
@@ -181,6 +181,11 @@ arxiv_post_2007_with_class_regexp = re.compile(
 """Matches new style arXiv ID, with an old-style class specification;
     technically malformed, however appears in real data."""
 
+hal_regexp = re.compile(
+    "(hal:|HAL:)?([a-z]{3}[a-z]*-|(sic|mem|ijn)_)\d{8}(v\d+)?$"
+    )
+"""Matches HAL identifiers (sic mem and ijn are old identifiers form)."""
+
 ads_regexp = re.compile("(ads:|ADS:)?(\d{4}[A-Za-z]\S{13}[A-Z.:])$")
 """See http://adsabs.harvard.edu/abs_doc/help_pages/data.html"""
 
@@ -454,6 +459,14 @@ def is_arxiv(val):
     return is_arxiv_post_2007(val) or is_arxiv_pre_2007(val)
 
 
+def is_hal(val):
+    """Test if argument is a HAL identifier.
+
+    See (https://hal.archives-ouvertes.fr)
+    """
+    return hal_regexp.match(val)
+
+
 def is_pmid(val):
     """Test if argument is a PubMed ID.
 
@@ -520,6 +533,7 @@ PID_SCHEMES = [
     ('urn', is_urn),
     ('ads', is_ads),
     ('arxiv', is_arxiv),
+    ('hal', is_hal),
     ('pmcid', is_pmcid),
     ('isbn', is_isbn),
     ('issn', is_issn),
@@ -644,6 +658,12 @@ def normalize_arxiv(val):
     return val
 
 
+def normalize_hal(val):
+    """Normalize a HAL identifier."""
+    val = val.replace(' ', '').lower().replace('hal:', '')
+    return val
+
+
 def normalize_isbn(val):
     """Normalize an ISBN identifier."""
     val = val.replace(' ', '').replace('-', '').strip().upper()
@@ -683,6 +703,8 @@ def normalize_pid(val, scheme):
         return normalize_isbn(val)
     elif scheme == 'issn':
         return normalize_issn(val)
+    elif scheme == 'hal':
+        return normalize_hal(val)
     return val
 
 
@@ -703,6 +725,7 @@ LANDING_URLS = {
     'uniprot': u'{scheme}://purl.uniprot.org/uniprot/{pid}',
     'refseq': u'{scheme}://www.ncbi.nlm.nih.gov/entrez/viewer.fcgi?val={pid}',
     'genome': u'{scheme}://www.ncbi.nlm.nih.gov/assembly/{pid}',
+    'hal': u'{scheme}://hal.archives-ouvertes.fr/{pid}',
 }
 """URL generation configuration for the supported PID providers."""
 

--- a/idutils/__init__.py
+++ b/idutils/__init__.py
@@ -1,8 +1,9 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of IDUtils
-# Copyright (C) 2015-2018 CERN.
+# Copyright (C) 2015-2019 CERN.
 # Copyright (C) 2018 Alan Rubin.
+# Copyright (C) 2019 Inria.
 #
 # IDUtils is free software; you can redistribute it and/or modify
 # it under the terms of the Revised BSD License; see LICENSE file for

--- a/idutils/version.py
+++ b/idutils/version.py
@@ -19,4 +19,4 @@ and parsed by ``setup.py``.
 
 from __future__ import absolute_import, print_function
 
-__version__ = "1.1.1dev20181118"
+__version__ = "1.1.2"

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ tests_require = [
     'pytest-cov>=1.8.0',
     'pytest-pep8>=1.0.6',
     'pytest-runner>=2.6.2',
-    'pytest>=3.3.0',
+    'pytest>=3.6.0',
 ]
 
 extras_require = {

--- a/tests/test_idutils.py
+++ b/tests/test_idutils.py
@@ -166,6 +166,12 @@ identifiers = [
         'http://www.ncbi.nlm.nih.gov/assembly/GCA_000002275.2'),
     ('GCF_000001405.38', ['genome', ], '',
         'http://www.ncbi.nlm.nih.gov/assembly/GCF_000001405.38'),
+    ('hal:inserm-13102590', ['hal', ], 'inserm-13102590',
+        'http://hal.archives-ouvertes.fr/inserm-13102590'),
+    ('inserm-13102590', ['hal', ], 'inserm-13102590',
+        'http://hal.archives-ouvertes.fr/inserm-13102590'),
+    ('mem_13102590', ['hal', ], 'mem_13102590',
+        'http://hal.archives-ouvertes.fr/mem_13102590'),
 ]
 
 


### PR DESCRIPTION
As discussed with Lars in october, here is a patch for idutils be able to managed Hal (hal.archives-ouvertes.fr) identifier.
Hope it's correcte (tests passed)