### PR TITLE
idutils: make DOI prefix with non-digit invalid

### DIFF
--- a/idutils/__init__.py
+++ b/idutils/__init__.py
@@ -142,7 +142,7 @@ ENSEMBL_PREFIXES = (
 """List of species-specific prefixes for Ensembl accession numbers."""
 
 doi_regexp = re.compile(
-    "(doi:\s*|(?:https?://)?(?:dx\.)?doi\.org/)?(10\.\d+(.\d+)*/.+)$",
+    r"(doi:\s*|(?:https?://)?(?:dx\.)?doi\.org/)?(10\.\d+(\.\d+)*/.+)$",
     flags=re.I
 )
 """See http://en.wikipedia.org/wiki/Digital_object_identifier."""

--- a/tests/test_idutils.py
+++ b/tests/test_idutils.py
@@ -256,7 +256,10 @@ def test_doi():
     """Test DOI validation."""
     assert idutils.is_doi('10.1000/123456')
     assert idutils.is_doi('10.1038/issn.1476-4687')
+    assert idutils.is_doi('10.1000.10/123456')
     assert not idutils.is_doi('10.1000/')
+    assert not idutils.is_doi('10.10O0/123456')
+    assert not idutils.is_doi('10.1.NOTGOOD.0/123456')
 
 
 def test_ascl():


### PR DESCRIPTION
Seems like a DOI prefix should really only be digits or periods, if I understand:

- https://www.doi.org/doi_handbook/2_Numbering.html#2.2
- https://en.wikipedia.org/wiki/Digital_object_identifier#Nomenclature_and_syntax
- https://support.datacite.org/docs/doi-basics#section-prefix

correctly. Before this PR, non-digits could sneak in as added tests showed. Now they can't (... if that's what we want :) ).