### PR TITLE
global: add support for Software Heritage identifiers

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -17,6 +17,7 @@ Authors
 - Adrian Pawel Baran
 - Alan Rubin
 - Alexander Ioannidis
+- Antoine Lambert
 - Bruno Marmol
 - Jiri Kuncar
 - Lars Holm Nielsen

--- a/idutils/__init__.py
+++ b/idutils/__init__.py
@@ -242,6 +242,11 @@ genome_regexp = re.compile("GC[AF]_\d+\.\d+$")
 ascl_regexp = re.compile("^ascl:[0-9]{4}\.[0-9]{3,4}$", flags=re.I)
 """ASCL regular expression."""
 
+swh_regexp = re.compile(
+    "swh:1:(cnt|dir|rel|rev|snp):[0-9a-f]{40}(;origin=\S+)?$"
+    )
+"""Matches Software Heritage identifiers."""
+
 
 def _convert_x_to_10(x):
     """Convert char to int with X being converted to 10."""
@@ -331,7 +336,7 @@ def is_handle(val):
     Note, DOIs are also handles, and handle are very generic so they will also
     match e.g. any URL your parse.
     """
-    return handle_regexp.match(val)
+    return handle_regexp.match(val) and not swh_regexp.match(val)
 
 
 def is_ean8(val):
@@ -534,6 +539,14 @@ def is_ascl(val):
     return ascl_regexp.match(val)
 
 
+def is_swh(val):
+    """Test if argument is a Software Heritage identifier.
+
+    https://docs.softwareheritage.org/devel/swh-model/persistent-identifiers.html
+    """
+    return swh_regexp.match(val)
+
+
 PID_SCHEMES = [
     ('doi', is_doi),
     ('ark', is_ark),
@@ -563,6 +576,7 @@ PID_SCHEMES = [
     ('uniprot', is_uniprot),
     ('refseq', is_refseq),
     ('genome', is_genome),
+    ('swh', is_swh),
 ]
 """Definition of scheme name and associated test function.
 
@@ -740,6 +754,7 @@ LANDING_URLS = {
     'refseq': u'{scheme}://www.ncbi.nlm.nih.gov/entrez/viewer.fcgi?val={pid}',
     'genome': u'{scheme}://www.ncbi.nlm.nih.gov/assembly/{pid}',
     'hal': u'{scheme}://hal.archives-ouvertes.fr/{pid}',
+    'swh': u'{scheme}://archive.softwareheritage.org/{pid}',
 }
 """URL generation configuration for the supported PID providers."""
 

--- a/tests/test_idutils.py
+++ b/tests/test_idutils.py
@@ -176,7 +176,34 @@ identifiers = [
         'http://hal.archives-ouvertes.fr/inserm-13102590'),
     ('mem_13102590', ['hal', ], 'mem_13102590',
         'http://hal.archives-ouvertes.fr/mem_13102590'),
-    ('ascl:1908.011', ['ascl', ], 'ascl:1908.011', 'http://ascl.net/1908.011')
+    ('ascl:1908.011', ['ascl', ], 'ascl:1908.011', 'http://ascl.net/1908.011'),
+    ('swh:1:cnt:94a9ed024d3859793618152ea559a168bbcbb5e2', ['swh', ],
+        'swh:1:cnt:94a9ed024d3859793618152ea559a168bbcbb5e2',
+        ('http://archive.softwareheritage.org/'
+         'swh:1:cnt:94a9ed024d3859793618152ea559a168bbcbb5e2')),
+    ('swh:1:dir:d198bc9d7a6bcf6db04f476d29314f157507d505', ['swh', ],
+        'swh:1:dir:d198bc9d7a6bcf6db04f476d29314f157507d505',
+        ('http://archive.softwareheritage.org/'
+         'swh:1:dir:d198bc9d7a6bcf6db04f476d29314f157507d505')),
+    ('swh:1:rev:309cf2674ee7a0749978cf8265ab91a60aea0f7d', ['swh', ],
+        'swh:1:rev:309cf2674ee7a0749978cf8265ab91a60aea0f7d',
+        ('http://archive.softwareheritage.org/'
+         'swh:1:rev:309cf2674ee7a0749978cf8265ab91a60aea0f7d')),
+    ('swh:1:rel:22ece559cc7cc2364edc5e5593d63ae8bd229f9f', ['swh', ],
+        'swh:1:rel:22ece559cc7cc2364edc5e5593d63ae8bd229f9f',
+        ('http://archive.softwareheritage.org/'
+         'swh:1:rel:22ece559cc7cc2364edc5e5593d63ae8bd229f9f')),
+    ('swh:1:snp:c7c108084bc0bf3d81436bf980b46e98bd338453', ['swh', ],
+        'swh:1:snp:c7c108084bc0bf3d81436bf980b46e98bd338453',
+        ('http://archive.softwareheritage.org/'
+         'swh:1:snp:c7c108084bc0bf3d81436bf980b46e98bd338453')),
+    (('swh:1:dir:d198bc9d7a6bcf6db04f476d29314f157507d505'
+      ';origin=https://github.com/user/repo'), ['swh', ],
+        ('swh:1:dir:d198bc9d7a6bcf6db04f476d29314f157507d505'
+         ';origin=https://github.com/user/repo'),
+        ('http://archive.softwareheritage.org/'
+         'swh:1:dir:d198bc9d7a6bcf6db04f476d29314f157507d505'
+         ';origin=https://github.com/user/repo')),
 ]
 
 


### PR DESCRIPTION
Add support for [Software Heritage](https://www.softwareheritage.org/) [persistent identifiers](https://docs.softwareheritage.org/devel/swh-model/persistent-identifiers.html) enabling to reference archived software artifacts:
- source file (named content in swh semantics)
- source tree (named directory in swh semantics)
- commit (named revision in swh semantics)
- release
- full set of branches of an archived repository (named snapshot in swh semantics)