### PR TITLE
ark: update NAAN regex [+]

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,10 @@
 Changes
 =======
 
+Version 1.1.9 (2021-08-30)
+
+- Update ARK's NAAN regex per https://datatracker.ietf.org/doc/html/draft-kunze-ark-28#section-2.3.
+
 Version 1.1.8 (2020-08-13)
 
 - Adds support for GEO and ArrayExpress identifiers.

--- a/idutils/__init__.py
+++ b/idutils/__init__.py
@@ -258,7 +258,7 @@ pmcid_regexp = re.compile(r"PMC\d+$", flags=re.I)
 pmid_regexp = re.compile(r"(pmid:)?(\d+)$", flags=re.I)
 """PubMed ID regular expression."""
 
-ark_suffix_regexp = re.compile(r"ark:/\d+/.+$")
+ark_suffix_regexp = re.compile(r"ark:/[0-9bcdfghjkmnpqrstvwxz]+/.+$")
 """See http://en.wikipedia.org/wiki/Archival_Resource_Key and
        https://confluence.ucop.edu/display/Curation/ARK."""
 

--- a/idutils/version.py
+++ b/idutils/version.py
@@ -17,4 +17,4 @@ This file is imported by ``idutils.__init__``,
 and parsed by ``setup.py``.
 """
 
-__version__ = "1.1.8"
+__version__ = "1.1.9"

--- a/tests/test_idutils.py
+++ b/tests/test_idutils.py
@@ -30,6 +30,7 @@ identifiers = [
         'http://nbn-resolving.org/urn:nbn:de:bvb:19-146642'),
     ('urn:lex:eu:council:directive:2010-03-09;2010-19-UE', ['urn', ], '', ''),
     ('ark:/13030/tqb3kh97gh8w', ['ark'], '', ''),
+    ('ark:/c8131/g3js3v', ['ark'], '', ''),
     ('http://www.example.org/ark:/13030/tqb3kh97gh8w', ['ark', 'url'], '', ''),
     ('10.1016/j.epsl.2011.11.037', ['doi', 'handle'],
         '10.1016/j.epsl.2011.11.037',


### PR DESCRIPTION
The spec for ARK identifiers has changed over the years.
It used to only allow digits for NAAN, but for a number
of years now, it has been accepting beta-numeric characters.
See https://datatracker.ietf.org/doc/html/draft-kunze-ark-28#section-2.3
