### PR TITLE
purl: adds purl.fdlp.gov as a valid PURL netloc

### DIFF
--- a/idutils/__init__.py
+++ b/idutils/__init__.py
@@ -537,9 +537,11 @@ def is_ark(val):
 def is_purl(val):
     """Test if argument is a PURL."""
     res = urlparse(val)
-    return (res.scheme == 'http' and
-            res.netloc in ['purl.org', 'purl.oclc.org', 'purl.net',
-                           'purl.com'] and
+    purl_netlocs = [
+        'purl.org', 'purl.oclc.org', 'purl.net', 'purl.com', 'purl.fdlp.gov'
+    ]
+    return (res.scheme in ['http', 'https'] and
+            res.netloc in purl_netlocs and
             res.path != '')
 
 

--- a/tests/test_idutils.py
+++ b/tests/test_idutils.py
@@ -95,6 +95,8 @@ identifiers = [
         'http://www.ncbi.nlm.nih.gov/pubmed/12082125'),
     ('http://purl.oclc.org/foo/bar', ['purl', 'url'], '',
         'http://purl.oclc.org/foo/bar'),
+    ('https://purl.fdlp.gov/GPO/gpo154197', ['purl', 'url'], '',
+        'https://purl.fdlp.gov/GPO/gpo154197'),
     ('http://www.heatflow.und.edu/index2.html', ['url'], '',
         'http://www.heatflow.und.edu/index2.html'),
     ('urn:nbn:de:101:1-201102033592', ['urn'], '',


### PR DESCRIPTION
purl.fdlp.gov is one of the oldest PURL provider and is
used by the US government for public access to digital
document despite service urls changing.

See https://en.wikipedia.org/wiki/Persistent_uniform_resource_locator

(NU needs this for migration of PURL alternative identifiers)