### PR TITLE
ci: install setuptools explicitly

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,7 +35,7 @@ jobs:
 
       - name: Generate dependencies
         run: |
-          pip install wheel requirements-builder
+          pip install setuptools wheel requirements-builder
           requirements-builder -e "$EXTRAS" --level=${{ matrix.requirements-level }} setup.py > .${{ matrix.requirements-level }}-${{ matrix.python-version }}-requirements.txt
 
       - name: Cache pip

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -322,4 +322,4 @@ texinfo_documents = [
 
 
 # Example configuration for intersphinx: refer to the Python standard library.
-intersphinx_mapping = {"https://docs.python.org/": None}
+intersphinx_mapping = {"<name>": ("https://docs.python.org/", None)}


### PR DESCRIPTION
Python v3.12 [doesn't install `setuptools` by default anymore in venvs](https://docs.python.org/3/whatsnew/3.12.html). Adding it explicitly in the `pip install ...` step.