### PR TITLE
setup: move importlib_metadata to setup.cfg

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,4 +1,4 @@
 [build-system]
-requires = ["setuptools", "wheel", "babel>2.8", "importlib_metadata"]
+requires = ["setuptools", "wheel", "babel>2.8"]
 build-backend = "setuptools.build_meta"
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -41,8 +41,11 @@ tests =
     pytest-black-ng>=0.4.0
     pytest-cache>=1.0
     pytest-runner>=2.6.2
-    pytest-invenio>=1.4.0
     sphinx>=4.5
+    check-manifest>=0.42
+    pytest-isort>=3.0.0
+    pytest-pydocstyle>=2.2.3
+    pytest-cov>=3.0.0
 # Kept for backwards compatibility
 docs =
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,6 +34,7 @@ zip_safe = False
 install_requires =
     six>=1.10
     isbnlib>=3.10.8
+    importlib-metadata>=6.11.0
 
 [options.extras_require]
 tests =


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description

Just having importlib_metadata in pyproject.toml doesn't install it for all use cases. It should be be in setup.cfg.



### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [x] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/contribute/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#third-party-codedependencies), please reach out to an [architect](https://github.com/orgs/inveniosoftware/teams/architects/members).


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
