### PR TITLE
Noref more permissive gnd uri handling

### DIFF
--- a/idutils/normalizers.py
+++ b/idutils/normalizers.py
@@ -54,8 +54,10 @@ def normalize_orcid(val):
 
 def normalize_gnd(val):
     """Normalize a GND identifier."""
-    if val.startswith(gnd_resolver_url):
-        val = val[len(gnd_resolver_url) :]
+    if val.startswith("http://" + gnd_resolver_url):
+        val = val[len("http://" + gnd_resolver_url) :]
+    elif val.startswith("https://" + gnd_resolver_url):
+        val = val[len("https://" + gnd_resolver_url) :]
     if val.lower().startswith("gnd:"):
         val = val[len("gnd:") :]
     return "gnd:{0}".format(val)

--- a/idutils/normalizers.py
+++ b/idutils/normalizers.py
@@ -54,13 +54,8 @@ def normalize_orcid(val):
 
 def normalize_gnd(val):
     """Normalize a GND identifier."""
-    if val.startswith("http://" + gnd_resolver_url):
-        val = val[len("http://" + gnd_resolver_url) :]
-    elif val.startswith("https://" + gnd_resolver_url):
-        val = val[len("https://" + gnd_resolver_url) :]
-    if val.lower().startswith("gnd:"):
-        val = val[len("gnd:") :]
-    return "gnd:{0}".format(val)
+    m = gnd_regexp.match(val)
+    return f"gnd:{m.group(2)}"
 
 
 def normalize_urn(val):

--- a/idutils/utils.py
+++ b/idutils/utils.py
@@ -83,7 +83,7 @@ See
 
 gnd_regexp = re.compile(
     r"(gnd:|GND:|https?://d-nb\.info/gnd/)?("
-    r"(1|10)\d{7}[0-9X]|"
+    r"1[012]?\d{7}[0-9X]|"
     r"[47]\d{6}-\d|"
     r"[1-9]\d{0,7}-[0-9X]|"
     r"3\d{7}[0-9X]"

--- a/idutils/utils.py
+++ b/idutils/utils.py
@@ -81,8 +81,10 @@ See
     https://support.orcid.org/hc/en-us/articles/360006897674-Structure-of-the-ORCID-Identifier
 """
 
+gnd_resolver_url = "d-nb.info/gnd/"
+
 gnd_regexp = re.compile(
-    r"(gnd:|GND:|http://d-nb.info/gnd/|https://d-nb.info/gnd/)?("
+    rf"(gnd:|GND:|http://{re.escape(gnd_resolver_url)}|https://{re.escape(gnd_resolver_url)})?("
     r"(1|10)\d{7}[0-9X]|"
     r"[47]\d{6}-\d|"
     r"[1-9]\d{0,7}-[0-9X]|"
@@ -91,7 +93,6 @@ gnd_regexp = re.compile(
 )
 """See https://www.wikidata.org/wiki/Property:P227."""
 
-gnd_resolver_url = "d-nb.info/gnd/"
 
 urn_resolver_url = "https://nbn-resolving.org/"
 

--- a/idutils/utils.py
+++ b/idutils/utils.py
@@ -82,7 +82,7 @@ See
 """
 
 gnd_regexp = re.compile(
-    r"(gnd:|GND:|https?://d-nb\.info/gnd/)?("
+    r"(gnd:|GND:|https?://d-nb\.info/gnd/|d-nb\.info/gnd/)?("
     r"1[012]?\d{7}[0-9X]|"
     r"[47]\d{6}-\d|"
     r"[1-9]\d{0,7}-[0-9X]|"

--- a/idutils/utils.py
+++ b/idutils/utils.py
@@ -82,7 +82,7 @@ See
 """
 
 gnd_regexp = re.compile(
-    r"(gnd:|GND:)?("
+    r"(gnd:|GND:|http://d-nb.info/gnd/|https://d-nb.info/gnd/)?("
     r"(1|10)\d{7}[0-9X]|"
     r"[47]\d{6}-\d|"
     r"[1-9]\d{0,7}-[0-9X]|"
@@ -91,7 +91,7 @@ gnd_regexp = re.compile(
 )
 """See https://www.wikidata.org/wiki/Property:P227."""
 
-gnd_resolver_url = "http://d-nb.info/gnd/"
+gnd_resolver_url = "d-nb.info/gnd/"
 
 urn_resolver_url = "https://nbn-resolving.org/"
 

--- a/idutils/utils.py
+++ b/idutils/utils.py
@@ -81,10 +81,8 @@ See
     https://support.orcid.org/hc/en-us/articles/360006897674-Structure-of-the-ORCID-Identifier
 """
 
-gnd_resolver_url = "d-nb.info/gnd/"
-
 gnd_regexp = re.compile(
-    rf"(gnd:|GND:|http://{re.escape(gnd_resolver_url)}|https://{re.escape(gnd_resolver_url)})?("
+    r"(gnd:|GND:|https?://d-nb\.info/gnd/)?("
     r"(1|10)\d{7}[0-9X]|"
     r"[47]\d{6}-\d|"
     r"[1-9]\d{0,7}-[0-9X]|"

--- a/idutils/validators.py
+++ b/idutils/validators.py
@@ -236,8 +236,6 @@ def is_pmcid(val):
 
 def is_gnd(val):
     """Test if argument is a GND Identifier."""
-    if val.startswith("d-nb.info/gnd/"):
-        val = val[len("d-nb.info/gnd/") :]
 
     return gnd_regexp.match(val)
 

--- a/idutils/validators.py
+++ b/idutils/validators.py
@@ -13,7 +13,6 @@
 
 """Utility file containing ID validators."""
 
-
 import unicodedata
 from urllib.parse import urlparse
 
@@ -237,8 +236,8 @@ def is_pmcid(val):
 
 def is_gnd(val):
     """Test if argument is a GND Identifier."""
-    if val.startswith(gnd_resolver_url):
-        val = val[len(gnd_resolver_url) :]
+    if val.startswith("d-nb.info/gnd/"):
+        val = val[len("d-nb.info/gnd/") :]
 
     return gnd_regexp.match(val)
 

--- a/idutils/validators.py
+++ b/idutils/validators.py
@@ -236,7 +236,6 @@ def is_pmcid(val):
 
 def is_gnd(val):
     """Test if argument is a GND Identifier."""
-
     return gnd_regexp.match(val)
 
 


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description

This PR aims at simplifying the process of adding a GND ID to a person in the creatibutors modal. Until now users could only paste the actual GND ID, not one of the GND URIs. When researching a GND URI the Website of the german national library looks like this: 

<img width="557" alt="image" src="https://github.com/user-attachments/assets/f395146c-01b8-467b-a667-92ecc9e979c4" />

So most people will just copy and paste this URI. When then saving or publishing the draft in RDM there will be a "Creators: No valid scheme recognized for identifier." error, which in our opinion is a major inconvenience.

This PR allows for pasting both `http://d-nb.info/gnd/<id>` and `https://d-nb.info/gnd/<id>` in addition to `GND:<id>`, `gnd:<id>` and `<id>`. The normalization step is the same as before.

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [ ] I've added relevant test cases.
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#third-party-codedependencies), please reach out to an [architect](https://github.com/orgs/inveniosoftware/teams/architects/members).