### PR TITLE
Update ARK validator

### DIFF
--- a/idutils/utils.py
+++ b/idutils/utils.py
@@ -65,9 +65,8 @@ pmid_regexp = re.compile(
 )
 """PubMed ID regular expression."""
 
-ark_suffix_regexp = re.compile(r"ark:/[0-9bcdfghjkmnpqrstvwxz]+/.+$")
-"""See http://en.wikipedia.org/wiki/Archival_Resource_Key and
-       https://confluence.ucop.edu/display/Curation/ARK."""
+ark_suffix_regexp = re.compile(r"ark:/?[0-9bcdfghjkmnpqrstvwxz]+/.+$")
+"""See https://datatracker.ietf.org/doc/html/draft-kunze-ark-41"""
 
 lsid_regexp = re.compile(r"urn:lsid:[^:]+(:[^:]+){2,3}$", flags=re.I)
 """See http://en.wikipedia.org/wiki/LSID."""
@@ -434,9 +433,9 @@ def _create_rfc3987_reg_exps():
 
 
 rfc3987_reg_exps = _create_rfc3987_reg_exps()
-""" 
-A dictionary of compiled regular expressions for RFC 3987. 
-The key is the grammar term and the value is the compiled regular expression. 
+"""
+A dictionary of compiled regular expressions for RFC 3987.
+The key is the grammar term and the value is the compiled regular expression.
 Some are used by SWH validation.
 """
 
@@ -454,7 +453,7 @@ swh_before_qualifiers_regexp = re.compile(
 
 swh_qualifier_values_regexp = re.compile(
     r"""
-    ^(?:  
+    ^(?:
         origin=(?P<origin_value>[^;]+)    # origin context qualifier
         | visit=(?P<visit>swh:1:(?:snp|rel|rev|dir|cnt):[0-9a-f]{40})  # visit context qualifier
         | anchor=(?P<anchor>swh:1:(?:snp|rel|rev|dir|cnt):[0-9a-f]{40}) # anchor context qualifier

--- a/tests/test_idutils.py
+++ b/tests/test_idutils.py
@@ -87,6 +87,7 @@ identifiers = [
     ),
     ("ark:/13030/tqb3kh97gh8w", ["ark"], "", ""),
     ("ark:/c8131/g3js3v", ["ark"], "", ""),
+    ("ark:c8131/g3js3v.1", ["ark"], "", ""),
     ("http://www.example.org/ark:/13030/tqb3kh97gh8w", ["ark", "url"], "", ""),
     (
         "10.1016/j.epsl.2011.11.037",


### PR DESCRIPTION
"/" after ark: is optional, ie ark:10001/... and ark:/10001/... are both valid. Spec reference in commit.

:heart: Thank you for your contribution!

### Description

> Please describe briefly your pull request.



### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [x] I've added relevant test cases.
- [x] I've added relevant documentation.
- [x] I've marked [translation strings](https://inveniordm.docs.cern.ch/develop/howtos/i18n/).
- [x] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/contribute/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#third-party-codedependencies), please reach out to an [architect on Discord](https://discord.gg/8qatqBC).

**Frontend**

- [ ] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/develop/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/develop/best-practices/react/) guidelines.
- [ ] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/develop/best-practices/accessibility/) guidelines.
- [ ] I've followed the [user interface](https://inveniordm.docs.cern.ch/develop/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
