### PR TITLE
RAiD support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -42,7 +42,7 @@ Features
 - Supported schemes: ISBN10, ISBN13, ISSN, ISTC, DOI, Handle, EAN8, EAN13, ISNI
   ORCID, ARK, PURL, LSID, URN, Bibcode, arXiv, PubMed ID, PubMed Central ID,
   GND, SRA, BioProject, BioSample, Ensembl, UniProt, RefSeq, GenBank/RefSeq, SWH,
-  OpenAlex, CSTR, RRID.
+  OpenAlex, CSTR, RRID, RAiD.
 
 Installation
 ============

--- a/idutils/normalizers.py
+++ b/idutils/normalizers.py
@@ -142,6 +142,12 @@ def normalize_openalex(val):
     return m.group(2).upper()
 
 
+def normalize_raid(val):
+    """Normalize a RAiD."""
+    m = raid_regexp.match(val)
+    return m.group(2)
+
+
 def normalize_pid(val, scheme):
     """Normalize an identifier.
 
@@ -181,6 +187,8 @@ def normalize_pid(val, scheme):
         return normalize_qid(val)
     elif scheme == "openalex":
         return normalize_openalex(val)
+    elif scheme == "raid":
+        return normalize_raid(val)
     else:
         for custom_scheme, normalizer in custom_schemes_registry().pick_scheme_key(
             "normalizer"
@@ -218,6 +226,7 @@ IDUTILS_LANDING_URLS = {
     "wikidata": "{scheme}://www.wikidata.org/entity/{pid}",
     "openalex": "{scheme}://openalex.org/{pid}",
     "rrid": "{scheme}://scicrunch.org/resolver/{pid}",
+    "raid": "{scheme}://raid.org/{pid}",
 }
 """URL generation configuration for the supported PID providers."""
 

--- a/idutils/schemes.py
+++ b/idutils/schemes.py
@@ -80,8 +80,8 @@ IDUTILS_SCHEME_FILTER = [
     ("wikidata", ["gnd", "viaf"]),
     # RAiDs are issued as DOIs via DataCite and reuse the DOI "10.xxxx/yyyy"
     # namespace, so a "10.xxxx/yyyy" value matches both; prefer "doi" so
-    # detection of existing DOIs is unaffected. Only the RAiD-exclusive
-    # "102.xxxx/yyyy" form (or a raid.org URL) is reported as "raid".
+    # detection of existing DOIs is unaffected. A raid.org URL is the only
+    # form that does not also match "doi", so it is reported as "raid".
     ("doi", ["raid"]),
 ]
 """(present_scheme, [list of schemes to remove if present_scheme found])."""

--- a/idutils/schemes.py
+++ b/idutils/schemes.py
@@ -50,6 +50,7 @@ IDUTILS_PID_SCHEMES = [
     ("openalex", validators.is_openalex),
     ("cstr", validators.is_cstr),
     ("rrid", validators.is_rrid),
+    ("raid", validators.is_raid),
 ]
 """Definition of scheme name and associated test function.
 
@@ -77,5 +78,10 @@ IDUTILS_SCHEME_FILTER = [
     ),
     ("pmid", ["viaf"]),
     ("wikidata", ["gnd", "viaf"]),
+    # RAiDs are issued as DOIs via DataCite and reuse the DOI "10.xxxx/yyyy"
+    # namespace, so a "10.xxxx/yyyy" value matches both; prefer "doi" so
+    # detection of existing DOIs is unaffected. Only the RAiD-exclusive
+    # "102.xxxx/yyyy" form (or a raid.org URL) is reported as "raid".
+    ("doi", ["raid"]),
 ]
 """(present_scheme, [list of schemes to remove if present_scheme found])."""

--- a/idutils/utils.py
+++ b/idutils/utils.py
@@ -19,13 +19,13 @@ doi_regexp = re.compile(
 """See http://en.wikipedia.org/wiki/Digital_object_identifier."""
 
 raid_regexp = re.compile(
-    r"((?:https?://)?raid\.org/)?(10[2]?\.\d+(\.\d+)*/.+)$", flags=re.I
+    r"((?:https?://)?raid\.org/)?(10\.\d+(\.\d+)*/.+)$", flags=re.I
 )
-"""See https://www.raid.org/ and
-       https://registry.identifiers.org/registry/raid.
+"""See https://www.raid.org/.
 
 RAiDs are issued as DOIs via DataCite, reusing the DOI "10.xxxx/yyyy"
-namespace; the "102.xxxx/yyyy" form is RAiD-exclusive. As with
+namespace; RAiD and DOI are format-identical, so there is no
+format-level way to distinguish a RAiD from a DOI. As with
 ``doi_regexp``, the trailing ``(\\.\\d+)*`` allows for sub-prefixes.
 """
 

--- a/idutils/utils.py
+++ b/idutils/utils.py
@@ -18,6 +18,17 @@ doi_regexp = re.compile(
 )
 """See http://en.wikipedia.org/wiki/Digital_object_identifier."""
 
+raid_regexp = re.compile(
+    r"((?:https?://)?raid\.org/)?(10[2]?\.\d+(\.\d+)*/.+)$", flags=re.I
+)
+"""See https://www.raid.org/ and
+       https://registry.identifiers.org/registry/raid.
+
+RAiDs are issued as DOIs via DataCite, reusing the DOI "10.xxxx/yyyy"
+namespace; the "102.xxxx/yyyy" form is RAiD-exclusive. As with
+``doi_regexp``, the trailing ``(\\.\\d+)*`` allows for sub-prefixes.
+"""
+
 handle_regexp = re.compile(
     r"(hdl:\s*|(?:https?://)?hdl\.handle\.net/)?" r"([^/.]+(\.[^/.]+)*/.*)$", flags=re.I
 )

--- a/idutils/validators.py
+++ b/idutils/validators.py
@@ -388,3 +388,15 @@ def is_cstr(val):
 def is_rrid(val):
     """Test if argument is a RRID."""
     return rrid_regexp.match(val)
+
+
+def is_raid(val):
+    """Test if argument is a RAiD (Research Activity Identifier).
+
+    Note, RAiDs are issued as DOIs via DataCite and reuse the DOI
+    "10.xxxx/yyyy" namespace, so a value may also validate as DOI/Handle.
+    Only the "102.xxxx/yyyy" form is RAiD-exclusive.
+
+    See https://www.raid.org/
+    """
+    return raid_regexp.match(val)

--- a/idutils/validators.py
+++ b/idutils/validators.py
@@ -395,7 +395,8 @@ def is_raid(val):
 
     Note, RAiDs are issued as DOIs via DataCite and reuse the DOI
     "10.xxxx/yyyy" namespace, so a value may also validate as DOI/Handle.
-    Only the "102.xxxx/yyyy" form is RAiD-exclusive.
+    RAiD and DOI are format-identical; there is no format-level
+    disambiguator.
 
     See https://www.raid.org/
     """

--- a/tests/test_idutils.py
+++ b/tests/test_idutils.py
@@ -814,6 +814,18 @@ identifiers = [
         "RRID:SCR_014641",
         "http://scicrunch.org/resolver/RRID:SCR_014641",
     ),
+    (
+        "102.26259/0e59e9a5",
+        ["handle", "raid"],
+        "102.26259/0e59e9a5",
+        "http://hdl.handle.net/102.26259/0e59e9a5",
+    ),
+    (
+        "https://raid.org/102.26259/0e59e9a5",
+        ["url", "raid"],
+        "https://raid.org/102.26259/0e59e9a5",
+        "https://raid.org/102.26259/0e59e9a5",
+    ),
 ]
 
 
@@ -1004,3 +1016,57 @@ def test_openalex():
     assert not idutils.is_openalex("Q303")
     assert not idutils.is_openalex("openalex:Q1234567")
     assert not idutils.is_openalex("https://openalex.org/Q1234567")
+
+
+def test_raid():
+    """Test RAiD validation and normalization."""
+    # Bare short forms.
+    assert idutils.is_raid("10.26259/0e59e9a5")
+    assert idutils.is_raid("102.26259/0e59e9a5")
+
+    # Full URL forms, including a mixed-case scheme/host.
+    assert idutils.is_raid("https://raid.org/10.26259/0e59e9a5")
+    assert idutils.is_raid("https://raid.org/102.26259/0e59e9a5")
+    assert idutils.is_raid("HTTPS://RAID.ORG/10.26259/0E59E9A5")
+
+    assert not idutils.is_raid("")
+    assert not idutils.is_raid("not-a-raid")
+    assert not idutils.is_raid("11.26259/0e59e9a5")  # neither 10. nor 102.
+
+    # Normalization strips the resolver prefix, leaving the bare form.
+    assert idutils.normalize_raid("10.26259/0e59e9a5") == "10.26259/0e59e9a5"
+    assert idutils.normalize_raid("102.26259/0e59e9a5") == "102.26259/0e59e9a5"
+    assert (
+        idutils.normalize_raid("https://raid.org/10.26259/0e59e9a5")
+        == "10.26259/0e59e9a5"
+    )
+    assert (
+        idutils.normalize_raid("HTTPS://RAID.ORG/102.26259/0E59E9A5")
+        == "102.26259/0E59E9A5"
+    )
+
+    # Resolver URL generation.
+    assert (
+        idutils.to_url("10.26259/0e59e9a5", "raid")
+        == "http://raid.org/10.26259/0e59e9a5"
+    )
+    assert (
+        idutils.to_url("10.26259/0e59e9a5", "raid", "https")
+        == "https://raid.org/10.26259/0e59e9a5"
+    )
+
+    # RAiDs are issued as DOIs via DataCite and reuse the DOI "10.xxxx/yyyy"
+    # namespace, so a "10." identifier validates as both DOI and RAiD; only
+    # "102." is RAiD-exclusive.
+    shared = "10.26259/0e59e9a5"
+    assert idutils.is_doi(shared)
+    assert idutils.is_raid(shared)
+
+    # detect_identifier_schemes() prefers "doi" for the shared namespace, so
+    # detection of existing DOIs is unaffected by RAiD support.
+    assert idutils.detect_identifier_schemes(shared) == ["doi", "handle"]
+
+    raid_only = "102.26259/0e59e9a5"
+    assert not idutils.is_doi(raid_only)
+    assert idutils.is_raid(raid_only)
+    assert "raid" in idutils.detect_identifier_schemes(raid_only)

--- a/tests/test_idutils.py
+++ b/tests/test_idutils.py
@@ -815,16 +815,16 @@ identifiers = [
         "http://scicrunch.org/resolver/RRID:SCR_014641",
     ),
     (
-        "102.26259/0e59e9a5",
-        ["handle", "raid"],
-        "102.26259/0e59e9a5",
-        "http://hdl.handle.net/102.26259/0e59e9a5",
+        "https://raid.org/10.83962/fb5be317",
+        ["url", "raid"],
+        "https://raid.org/10.83962/fb5be317",
+        "https://raid.org/10.83962/fb5be317",
     ),
     (
-        "https://raid.org/102.26259/0e59e9a5",
+        "https://raid.org/10.83962/f2a7645d",
         ["url", "raid"],
-        "https://raid.org/102.26259/0e59e9a5",
-        "https://raid.org/102.26259/0e59e9a5",
+        "https://raid.org/10.83962/f2a7645d",
+        "https://raid.org/10.83962/f2a7645d",
     ),
 ]
 
@@ -1022,27 +1022,27 @@ def test_raid():
     """Test RAiD validation and normalization."""
     # Bare short forms.
     assert idutils.is_raid("10.26259/0e59e9a5")
-    assert idutils.is_raid("102.26259/0e59e9a5")
+    assert idutils.is_raid("10.83962/fb5be317")
 
     # Full URL forms, including a mixed-case scheme/host.
     assert idutils.is_raid("https://raid.org/10.26259/0e59e9a5")
-    assert idutils.is_raid("https://raid.org/102.26259/0e59e9a5")
+    assert idutils.is_raid("https://raid.org/10.83962/f2a7645d")
     assert idutils.is_raid("HTTPS://RAID.ORG/10.26259/0E59E9A5")
 
     assert not idutils.is_raid("")
     assert not idutils.is_raid("not-a-raid")
-    assert not idutils.is_raid("11.26259/0e59e9a5")  # neither 10. nor 102.
+    assert not idutils.is_raid("11.26259/0e59e9a5")  # does not start with 10
+    assert not idutils.is_raid("102.26259/0e59e9a5")  # "102." is not a real RAiD prefix
 
     # Normalization strips the resolver prefix, leaving the bare form.
     assert idutils.normalize_raid("10.26259/0e59e9a5") == "10.26259/0e59e9a5"
-    assert idutils.normalize_raid("102.26259/0e59e9a5") == "102.26259/0e59e9a5"
     assert (
         idutils.normalize_raid("https://raid.org/10.26259/0e59e9a5")
         == "10.26259/0e59e9a5"
     )
     assert (
-        idutils.normalize_raid("HTTPS://RAID.ORG/102.26259/0E59E9A5")
-        == "102.26259/0E59E9A5"
+        idutils.normalize_raid("HTTPS://RAID.ORG/10.26259/0E59E9A5")
+        == "10.26259/0E59E9A5"
     )
 
     # Resolver URL generation.
@@ -1056,17 +1056,17 @@ def test_raid():
     )
 
     # RAiDs are issued as DOIs via DataCite and reuse the DOI "10.xxxx/yyyy"
-    # namespace, so a "10." identifier validates as both DOI and RAiD; only
-    # "102." is RAiD-exclusive.
-    shared = "10.26259/0e59e9a5"
-    assert idutils.is_doi(shared)
-    assert idutils.is_raid(shared)
+    # namespace, so RAiD and DOI are format-identical; there is no
+    # format-level disambiguator. Any "10.xxxx/yyyy" identifier validates as
+    # both DOI and RAiD.
+    for shared in ("10.26259/0e59e9a5", "10.83962/fb5be317"):
+        assert idutils.is_doi(shared)
+        assert idutils.is_raid(shared)
 
     # detect_identifier_schemes() prefers "doi" for the shared namespace, so
-    # detection of existing DOIs is unaffected by RAiD support.
-    assert idutils.detect_identifier_schemes(shared) == ["doi", "handle"]
-
-    raid_only = "102.26259/0e59e9a5"
-    assert not idutils.is_doi(raid_only)
-    assert idutils.is_raid(raid_only)
-    assert "raid" in idutils.detect_identifier_schemes(raid_only)
+    # detection of existing DOIs is unaffected by RAiD support. A raid.org
+    # URL is the only form reported as "raid".
+    assert idutils.detect_identifier_schemes("10.26259/0e59e9a5") == ["doi", "handle"]
+    assert "raid" in idutils.detect_identifier_schemes(
+        "https://raid.org/10.83962/fb5be317"
+    )


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description

This is a bug fixed implementation of RAiD support based on the work by Jason Wohlgemuth in acorn-cli. The incorrect support for "102." prefixes has been removed.


### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [X] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/community/code-of-conduct/).
- [X] I've created [logical separate commits](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commit-message).
- [X] I've added relevant test cases.
- [ ] I've added relevant documentation.
- [ ] I've marked [translation strings](https://inveniordm.docs.cern.ch/community/translations/i18n/).
- [ ] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/community/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [X] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#third-party-codedependencies), please reach out to an [architect on Discord](https://discord.gg/8qatqBC).

**Frontend**

- [ ] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/community/code/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/community/code/best-practices/react/) guidelines.
- [ ] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/community/code/best-practices/accessibility/) guidelines.
- [ ] I've followed the [user interface](https://inveniordm.docs.cern.ch/community/code/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
