### PR TITLE
feat(ensembl): support versioned Ensembl IDs

### DIFF
--- a/idutils/normalizers.py
+++ b/idutils/normalizers.py
@@ -260,6 +260,8 @@ def to_url(val, scheme, url_scheme="http"):
                 pid = pid[len("wikidata:") :]
         if scheme == "openalex":
             url_scheme = "https"
+        if scheme == "ensembl":
+            pid = pid.split(".")[0]
         return landing_urls[scheme].format(scheme=url_scheme, pid=pid)
     elif scheme in ["purl", "url"]:
         return pid

--- a/idutils/utils.py
+++ b/idutils/utils.py
@@ -247,7 +247,7 @@ See https://asia.ensembl.org/info/genome/stable_ids/prefixes.html
 """
 
 ensembl_regexp = re.compile(
-    r"({prefixes})(E|FM|G|GT|P|R|T)\d{{11}}$".format(
+    r"({prefixes})(E|FM|G|GT|P|R|T)\d{{11}}(\.\d+)?$".format(
         prefixes="|".join(ENSEMBL_PREFIXES)
     )
 )

--- a/tests/test_idutils.py
+++ b/tests/test_idutils.py
@@ -461,6 +461,14 @@ identifiers = [
         "http://www.ensembl.org/id/ENSMUST00000017290",
     ),
     (
+        "ENSG00000012048.15",
+        [
+            "ensembl",
+        ],
+        "",
+        "http://www.ensembl.org/id/ENSG00000012048",
+    ),
+    (
         "P02833",
         [
             "uniprot",


### PR DESCRIPTION
### Description

Accept an optional version suffix (e.g. ENSG00000012048.15) in the Ensembl regexp, matching the version handling already used by the uniprot and refseq patterns. The version is preserved by normalization (as with refseq) and stripped only when generating a landing-page URL.

Add a test case covering detection, normalization and URL generation for a versioned ID.

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/community/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commit-message).
- [x] I've added relevant test cases.
- [x] I've added relevant documentation.
- [ ] I've marked [translation strings](https://inveniordm.docs.cern.ch/community/translations/i18n/).
- [ ] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/community/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#third-party-codedependencies), please reach out to an [architect on Discord](https://discord.gg/8qatqBC).

**Frontend**

- [ ] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/community/code/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/community/code/best-practices/react/) guidelines.
- [ ] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/community/code/best-practices/accessibility/) guidelines.
- [ ] I've followed the [user interface](https://inveniordm.docs.cern.ch/community/code/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
