### PR TITLE
fix(ror): reject ids outside the Crockford alphabet and bad checksums

### DIFF
--- a/idutils/utils.py
+++ b/idutils/utils.py
@@ -471,8 +471,21 @@ swh_qualifier_values_regexp = re.compile(
 
 """Matches Software Heritage identifiers."""
 
-ror_regexp = re.compile(r"(?:https?://)?(?:ror\.org/)?(0\w{6}\d{2})$", flags=re.I)
-"""See https://ror.org/facts/#core-components."""
+ROR_ALPHABET = "0123456789abcdefghjkmnpqrstvwxyz"
+"""Crockford base 32 alphabet used by the ROR identifier pattern.
+
+It excludes the letters "i", "l", "o" and "u".
+
+See https://ror.readme.io/docs/identifier.
+"""
+
+ror_regexp = re.compile(
+    r"(?:https?://)?(?:ror\.org/)?(0[{alphabet}]{{6}}\d{{2}})$".format(
+        alphabet=ROR_ALPHABET
+    ),
+    flags=re.I,
+)
+"""See https://ror.readme.io/docs/identifier."""
 
 viaf_urls = [
     "http://viaf.org/viaf/",

--- a/idutils/validators.py
+++ b/idutils/validators.py
@@ -337,8 +337,24 @@ def is_swh(val):
 
 
 def is_ror(val):
-    """Test if argument is a ROR id."""
-    return ror_regexp.match(val)
+    """Test if argument is a ROR id.
+
+    The nine character ROR id is a zero, six characters of the Crockford
+    base 32 alphabet (which excludes "i", "l", "o" and "u") and a two
+    digit checksum following ISO/IEC 7064:2003.
+
+    See https://ror.readme.io/docs/identifier.
+    """
+    m = ror_regexp.match(val)
+    if m is None:
+        return None
+    identifier = m.group(1).lower()
+    number = 0
+    for char in identifier[1:7]:
+        number = number * 32 + ROR_ALPHABET.index(char)
+    if int(identifier[7:]) != 98 - (number * 100) % 97:
+        return None
+    return m
 
 
 def is_viaf(val):

--- a/tests/test_idutils.py
+++ b/tests/test_idutils.py
@@ -1026,6 +1026,18 @@ def test_openalex():
     assert not idutils.is_openalex("https://openalex.org/Q1234567")
 
 
+def test_ror():
+    """Test ROR validation."""
+    assert idutils.is_ror("03yrm5c26")
+    assert idutils.is_ror("https://ror.org/05dxps055")
+    # "i", "l", "o" and "u" are not in the Crockford base 32 alphabet.
+    assert not idutils.is_ror("0iiiiii99")
+    assert not idutils.is_ror("0lououi99")
+    # A single character typo breaks the ISO/IEC 7064 checksum.
+    assert not idutils.is_ror("05dxps056")
+    assert not idutils.is_ror("05dxqs055")
+
+
 def test_raid():
     """Test RAiD validation and normalization."""
     # Bare short forms.


### PR DESCRIPTION
### Description

`is_ror` accepts strings ROR cannot issue, because `ror_regexp` matches the six character body with `\w`.

ROR's documentation (https://ror.readme.io/docs/identifier) says the id "uses base 32 Crockford encoding, which excludes letters 'I', 'L', 'O', and 'U'", and that "the last 2 digits of the ROR identifier are a checksum that follows the ISO/IEC 7064:2003 standard". `\w` admits `i`, `l`, `o`, `u` and `_`, and the checksum is never verified, so on master `is_ror("0iiiiii99")`, `is_ror("0______12")` and `is_ror("05dxps056")` — one digit off Caltech's real `05dxps055` — all pass.

That matters downstream: `idutils.is_ror` is the validator InvenioRDM registers for the ROR scheme it sends to DataCite (`invenio_rdm_records/config.py`), and invenio-vocabularies uses it for affiliations and funders, so a mistyped organisation id reaches the record.

This builds the character class from the Crockford alphabet and verifies the MOD 97-10 checksum — the same check digit validation this library already does for ISBN, ISSN, ISNI, ORCID, EAN-8, EAN-13 and ISTC. ROR was the outlier.

Measured against the complete ROR registry dump (v2.12, 2026-08-25, 137,398 ids): **0 rejected**, so no real id regresses. Over 648,000 single character typos of 2,000 real ids, master accepts 468,000 (72%) and this accepts 0. Fixing only the character class still accepts 408,000, which is why the checksum is here too.

One caveat worth your call: this is a tightening, so an instance holding malformed ROR values would start failing validation on them. In invenio-vocabularies two fabricated funder ids in test fixtures (`0aaaaaa11`, `0aaaaaa22`) would be rejected. If you would rather land only the alphabet half, or gate the checksum, say so and I will split it.

Existing ROR coverage is one positive id, so `test_ror` adds the negative cases; all four fail on master.

The reference URL is updated as well — `https://ror.org/facts/#core-components` now returns 404.

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [ ] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/community/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commit-message).
- [x] I've added relevant test cases.
- [x] I've added relevant documentation.
- [ ] I've marked [translation strings](https://inveniordm.docs.cern.ch/community/translations/i18n/).
- [ ] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/community/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).

**Frontend**

- [ ] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/community/code/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/community/code/best-practices/react/) guidelines.
- [ ] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/community/code/best-practices/accessibility/) guidelines.
- [ ] I've followed the [user interface](https://inveniordm.docs.cern.ch/community/code/best-practices/ui/) guidelines.
